### PR TITLE
Fix code scanning alert no. 5: Multiplication result converted to larger type

### DIFF
--- a/code/qcommon/cm_test.c
+++ b/code/qcommon/cm_test.c
@@ -494,7 +494,7 @@ void	CM_ReadPortalState( fileHandle_t f )
 	if (numareaportals != cm.numAreas) {
 		Com_Error(ERR_DROP, "numareaportals differs from save game");
 	}
-	FS_Read(cm.areaPortals, cm.numAreas * cm.numAreas * sizeof(*cm.areaPortals), f);
+	FS_Read(cm.areaPortals, (unsigned long)cm.numAreas * cm.numAreas * sizeof(*cm.areaPortals), f);
 	CM_FloodAreaConnections();
 }
 


### PR DESCRIPTION
### Description

In this pull request, there is a modification made to the `CM_ReadPortalState` function in the `cm_test.c` file. The change involves casting the expression `(cm.numAreas * cm.numAreas * sizeof(*cm.areaPortals))` to `unsigned long` in the `FS_Read` function call. This casting ensures that the result of the expression is correctly handled as an `unsigned long` datatype.

Changes:
- Cast the expression `(cm.numAreas * cm.numAreas * sizeof(*cm.areaPortals))` to `unsigned long` in the `FS_Read` function call.